### PR TITLE
Adding touchevents to Farbtastic

### DIFF
--- a/src/farbtastic.js
+++ b/src/farbtastic.js
@@ -134,6 +134,7 @@ $._farbtastic = function (container, options) {
     // Draw widget base layers.
     fb.drawCircle();
     fb.drawMask();
+    fb.bindTouch();
   }
 
   /**
@@ -447,16 +448,18 @@ $._farbtastic = function (container, options) {
   }
 
   // TouchStart bound, calls conversion of touchpoints to mousepoints
-  $('*', e).bind("touchstart", function (e) {
-    // Capture mouse
-    if (!document.dragging) {
-      $(document).bind('touchmove', fb.touchmove).bind('touchend', fb.touchend);
-      document.dragging = true;
-    }
-    fb.mousedown( fb.touchconvert(e) );
-    e.preventDefault();
-    return false;
-  });
+  fb.bindTouch = function() {
+    $('*', container).bind("touch touchstart", function (e) {
+      // Capture mouse
+      if (!document.dragging) {
+        $(document).bind('touchmove', fb.touchmove).bind('touchend', fb.touchend);
+        document.dragging = true;
+      }
+      fb.mousedown( fb.touchconvert(e) );
+      e.preventDefault();
+      return false;
+    });
+  }
 
   /* Various color utility functions */
   fb.dec2hex = function (x) {

--- a/src/farbtastic.js
+++ b/src/farbtastic.js
@@ -418,6 +418,46 @@ $._farbtastic = function (container, options) {
     $._farbtastic.dragging = false;
   }
 
+  /**
+   * TouchConvert: Converts touch co-ordinates to mouse co-ordinates
+   */
+  fb.touchconvert = function (e) {
+    var e = e.originalEvent.touches.item(0);
+    return e;
+  }
+
+  /**
+   * Touchmove handler for iPad, iPhone etc
+   */
+  fb.touchmove = function (e) {
+    fb.mousemove( fb.touchconvert(e)  );
+    event.preventDefault();
+    return false;
+  }
+
+  /**
+   * Touchend handler for iPad, iPhone etc
+   */
+  fb.touchend = function (event) {
+    $(document).unbind('touchmove', fb.touchmove);
+    $(document).unbind('touchend', fb.touchend);
+    document.dragging = false;
+    event.preventDefault();
+    return false;
+  }
+
+  // TouchStart bound, calls conversion of touchpoints to mousepoints
+  $('*', e).bind("touchstart", function (e) {
+    // Capture mouse
+    if (!document.dragging) {
+      $(document).bind('touchmove', fb.touchmove).bind('touchend', fb.touchend);
+      document.dragging = true;
+    }
+    fb.mousedown( fb.touchconvert(e) );
+    e.preventDefault();
+    return false;
+  });
+
   /* Various color utility functions */
   fb.dec2hex = function (x) {
     return (x < 16 ? '0' : '') + x.toString(16);


### PR DESCRIPTION
Using the guide from [http://www.signedon.com/adding-ios-touch-events-to-farbtastic-color-picker/](http://www.signedon.com/adding-ios-touch-events-to-farbtastic-color-picker/) I was able to add touchevents to farbtastic. 

Opening pull request so others can use this too.
